### PR TITLE
Enhance product page UI

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -172,10 +172,10 @@ a:hover {
 
 .product-detail__item {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+  grid-template-columns: 1fr 1fr;
   gap: 2rem;
   justify-items: center;
-  flex-wrap: wrap;
+  align-items: start;
 }
 
 .product-detail__item-image-wrapper {
@@ -189,6 +189,27 @@ a:hover {
   width: 100%;
   height: 100%;
   object-fit: cover;
+}
+
+.product-nav {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+
+.quantity-controls {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 1rem 0;
+}
+
+.qty-btn {
+  padding: 0.25rem 0.75rem;
+  background: var(--surface-medium);
+  border: none;
+  border-radius: 0.25rem;
+  cursor: pointer;
 }
 
 /*-----------------------------
@@ -305,5 +326,9 @@ a:hover {
     margin-left: 0;
     padding: 3rem;
     gap: 3rem;
+  }
+
+  .product-detail__item {
+    grid-template-columns: 1fr;
   }
 }

--- a/js/product.js
+++ b/js/product.js
@@ -1,15 +1,64 @@
-import { addToCart, updateCartCount } from './cart.js';
+import { addToCart, updateCartCount, getCart, saveCart } from './cart.js';
 
 document.addEventListener('DOMContentLoaded', () => {
   updateCartCount();
 
   let product;
+  let products;
   const params = new URLSearchParams(window.location.search);
   const itemId = params.get('item');
 
+  const qtyEl = document.getElementById('cart-quantity');
+  const incBtn = document.getElementById('increase-qty');
+  const decBtn = document.getElementById('decrease-qty');
+  const prevLink = document.getElementById('prev-product');
+  const nextLink = document.getElementById('next-product');
+
+  function currentQuantity() {
+    const cart = getCart();
+    const item = cart.find(p => p['Item No.'] === itemId);
+    return item ? (item.quantity || 1) : 0;
+  }
+
+  function updateQtyDisplay(qty) {
+    qtyEl.textContent = qty;
+  }
+
+  function changeQuantity(action) {
+    const cart = getCart();
+    const idx = cart.findIndex(p => p['Item No.'] === itemId);
+    let qty = 0;
+
+    if (idx === -1) {
+      if (action === 'increase') {
+        product.quantity = 1;
+        cart.push(product);
+        qty = 1;
+      }
+    } else {
+      qty = cart[idx].quantity || 1;
+      if (action === 'increase') {
+        qty += 1;
+        cart[idx].quantity = qty;
+      } else {
+        qty = Math.max(0, qty - 1);
+        if (qty === 0) {
+          cart.splice(idx, 1);
+        } else {
+          cart[idx].quantity = qty;
+        }
+      }
+    }
+
+    saveCart(cart);
+    updateCartCount();
+    updateQtyDisplay(qty);
+  }
+
   fetch('data/products.json')
     .then(res => res.json())
-    .then(products => {
+    .then(data => {
+      products = data;
       product = products.find(p => p["Item No."] === itemId);
 
       const titleEl            = document.getElementById('product-title');
@@ -38,6 +87,20 @@ document.addEventListener('DOMContentLoaded', () => {
       img.alt    = product["Item Description"];
       img.onerror = () => img.src = 'images/placeholder.webp';
 
+      const index = products.findIndex(p => p['Item No.'] === itemId);
+      if (index > 0) {
+        prevLink.href = `product.html?item=${products[index - 1]['Item No.']}`;
+      } else {
+        prevLink.style.visibility = 'hidden';
+      }
+      if (index < products.length - 1) {
+        nextLink.href = `product.html?item=${products[index + 1]['Item No.']}`;
+      } else {
+        nextLink.style.visibility = 'hidden';
+      }
+
+      updateQtyDisplay(currentQuantity());
+
     })
     .catch(err => {
       console.error('Error loading product:', err);
@@ -53,6 +116,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const result = addToCart(product);
 
     updateCartCount();
+    updateQtyDisplay(currentQuantity());
 
     if (result.added) {
       feedback.textContent = '✅ Added to cart!';
@@ -63,6 +127,14 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     setTimeout(() => feedback.textContent = '', 2000);
+  });
+
+  incBtn.addEventListener('click', () => {
+    if (product) changeQuantity('increase');
+  });
+
+  decBtn.addEventListener('click', () => {
+    if (product) changeQuantity('decrease');
   });
 });
 

--- a/product.html
+++ b/product.html
@@ -49,13 +49,15 @@
         <img id="product-image" src="" alt="Product Image" class="product-detail__item-image" />
       </div>
 
-      <div style="flex: 1;">
-        <a href="./" aria-label="Back to Home">
-          <span class="material-symbols-outlined">keyboard_arrow_left</span>
-        </a>
-        <a href="./" aria-label="Back to Home">
-          <span class="material-symbols-outlined">keyboard_arrow_right</span>
-        </a>
+      <div class="product-detail__item-info">
+        <div class="product-nav">
+          <a id="prev-product" aria-label="Previous product">
+            <span class="material-symbols-outlined">keyboard_arrow_left</span>
+          </a>
+          <a id="next-product" aria-label="Next product">
+            <span class="material-symbols-outlined">keyboard_arrow_right</span>
+          </a>
+        </div>
 
         <h1 id="product-title">Loading...</h1>
         <p><strong>Item No:</strong> <span id="product-id"></span></p>
@@ -63,7 +65,15 @@
         <p><strong>Stock:</strong> <span id="product-stock-quantity"></span></p>
         <p><strong>Item Group:</strong> <span id="product-group"></span></p>
         <p><strong>Price:</strong> <span id="product-price"></span></p>
+
+        <div class="quantity-controls">
+          <button id="decrease-qty" class="qty-btn" aria-label="Decrease quantity">−</button>
+          <span id="cart-quantity">0</span>
+          <button id="increase-qty" class="qty-btn" aria-label="Increase quantity">+</button>
+        </div>
+
         <button id="add-to-cart" class="button">Add to Cart</button>
+        <a href="cart.html" class="button">Checkout</a>
         <div id="cart-feedback"></div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- split product page with 50/50 image and info
- add previous/next navigation
- show cart quantity with ability to adjust
- include checkout link

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68469d3177048333860d5e3b0c5c5af9